### PR TITLE
Workaround to get a list of identities

### DIFF
--- a/crypto/keyring.go
+++ b/crypto/keyring.go
@@ -24,6 +24,10 @@ type Identity struct {
 	Email string
 }
 
+type IdentitySlice struct {
+	identities []*Identity
+}
+
 // --- New keyrings
 
 // NewKeyRing creates a new KeyRing, empty if key is nil.
@@ -101,7 +105,7 @@ func (keyRing *KeyRing) CountDecryptionEntities() int {
 }
 
 // GetIdentities returns the list of identities associated with this key ring.
-func (keyRing *KeyRing) GetIdentities() []*Identity {
+func (keyRing *KeyRing) GetIdentities() IdentitySlice {
 	var identities []*Identity
 	for _, e := range keyRing.entities {
 		for _, id := range e.Identities {
@@ -111,7 +115,17 @@ func (keyRing *KeyRing) GetIdentities() []*Identity {
 			})
 		}
 	}
-	return identities
+	return IdentitySlice{identities: identities}
+}
+
+// GetAt returns the item at index n for the given identity slice
+func (identitySlice *IdentitySlice) GetAt(n int) *Identity {
+	return identitySlice.identities[n]
+}
+
+// Len returns the length of the IdentitySlice
+func (identitySlice *IdentitySlice) Len() int {
+	return len(identitySlice.identities)
 }
 
 // CanVerify returns true if any of the keys in the keyring can be used for verification.

--- a/crypto/keyring.go
+++ b/crypto/keyring.go
@@ -105,7 +105,7 @@ func (keyRing *KeyRing) CountDecryptionEntities() int {
 }
 
 // GetIdentities returns the list of identities associated with this key ring.
-func (keyRing *KeyRing) GetIdentities() IdentitySlice {
+func (keyRing *KeyRing) GetIdentities() *IdentitySlice {
 	var identities []*Identity
 	for _, e := range keyRing.entities {
 		for _, id := range e.Identities {
@@ -115,7 +115,7 @@ func (keyRing *KeyRing) GetIdentities() IdentitySlice {
 			})
 		}
 	}
-	return IdentitySlice{identities: identities}
+	return &IdentitySlice{identities: identities}
 }
 
 // GetAt returns the item at index n for the given identity slice

--- a/crypto/keyring_test.go
+++ b/crypto/keyring_test.go
@@ -88,8 +88,8 @@ func initKeyRings() {
 
 func TestIdentities(t *testing.T) {
 	identities := keyRingTestPrivate.GetIdentities()
-	assert.Len(t, identities, 1)
-	assert.Exactly(t, identities[0], testIdentity)
+	assert.Len(t, identities.identities, 1)
+	assert.Exactly(t, identities.GetAt(0), testIdentity)
 }
 
 func TestFilterExpiredKeys(t *testing.T) {


### PR DESCRIPTION
Create a wrapper type with a non-exported slice of identities, which contains exported methods for working with the wrapped slice.

Also update tests to match.